### PR TITLE
Update propel.sample to fix Models paht on Linux

### DIFF
--- a/propel/propel.sample
+++ b/propel/propel.sample
@@ -6,7 +6,7 @@
             <version>1.0.0</version>
         </general>
         <paths>
-            <phpDir>..</phpDir>
+            <phpDir>../app/Models</phpDir>
             <composerDir>..</composerDir>
         </paths>
         <database>
@@ -26,6 +26,7 @@
             <schema>
                 <autoPackage>true</autoPackage>
             </schema>
+            <namespaceAutoPackage>false</namespaceAutoPackage>
         </generator>
     </propel>
 </config>


### PR DESCRIPTION
Fix wrong Models path on Linux (Ubuntu) machines.
Propels is generating the classfiles on Ubuntu in `App/Models` instead of `app/Models`
I've found this solution on [Stackoverflow](https://stackoverflow.com/a/38922288) 